### PR TITLE
feat: Send CloudEvents for Watch Events

### DIFF
--- a/cmd/test-receiver/main.go
+++ b/cmd/test-receiver/main.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2023 The KubeArchive Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/kubearchive/dynowatch/internal/cloudevents/test"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var mainLog = ctrl.Log.WithName("main")
+
+func main() {
+	var addr string
+
+	flag.StringVar(&addr, "address", ":8080", "The address to listen to.")
+	opts := &zap.Options{
+		Development: true,
+	}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(opts)))
+
+	ctx := ctrl.SetupSignalHandler()
+	handler, err := test.NewReceiverHTTPHandler(ctx, nil)
+	if err != nil {
+		mainLog.Error(err, "failed to create CloudEventHandler")
+		os.Exit(1)
+	}
+	server := &http.Server{
+		Addr:    addr,
+		Handler: handler,
+	}
+	mainLog = mainLog.WithValues("address", addr)
+	mainLog.Info("running cloudEvent receiver")
+	go func() {
+		if err := server.ListenAndServe(); !errors.Is(http.ErrServerClosed, err) {
+			mainLog.Error(err, "error running HTTP receiver")
+			os.Exit(1)
+		}
+	}()
+	mainLog.Info("cloudEvent receiver started")
+	<-ctx.Done()
+	mainLog.Info("shutdown signal received")
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		mainLog.Error(err, "failed to shut down receiver")
+	}
+	mainLog.Info("shutdown complete")
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/kubearchive/dynowatch
 go 1.20
 
 require (
+	github.com/cloudevents/sdk-go/v2 v2.12.0
+	github.com/go-logr/logr v1.2.4
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	k8s.io/api v0.28.3
@@ -18,7 +20,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/zapr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/cloudevents/sdk-go/v2 v2.12.0 h1:p1k+ysVOZtNiXfijnwB3WqZNA3y2cGOiKQygWkUHCEI=
+github.com/cloudevents/sdk-go/v2 v2.12.0/go.mod h1:xDmKfzNjM8gBvjaF8ijFjM1VYOVUEeUfapHMUX1T5To=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -110,6 +112,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/internal/cloudevents/test/event_recorder.go
+++ b/internal/cloudevents/test/event_recorder.go
@@ -1,0 +1,52 @@
+package test
+
+import (
+	"sync"
+	"sync/atomic"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
+
+type EventRecorder struct {
+	recordLock sync.Mutex
+	recording  *atomic.Bool
+	events     []cloudevents.Event
+}
+
+func NewEventRecorder() *EventRecorder {
+	return &EventRecorder{
+		events:    []cloudevents.Event{},
+		recording: &atomic.Bool{},
+	}
+}
+
+func (e *EventRecorder) Start() {
+	e.recording.Store(true)
+}
+
+func (e *EventRecorder) Stop() {
+	e.recording.Store(false)
+}
+
+func (e *EventRecorder) Record(event cloudevents.Event) {
+	if !e.recording.Load() {
+		return
+	}
+	e.recordLock.Lock()
+	defer e.recordLock.Unlock()
+	e.events = append(e.events, event)
+
+}
+
+func (e *EventRecorder) Events() []cloudevents.Event {
+	e.recordLock.Lock()
+	defer e.recordLock.Unlock()
+	events := append([]cloudevents.Event{}, e.events...)
+	return events
+}
+
+func (e *EventRecorder) Clear() {
+	e.recordLock.Lock()
+	defer e.recordLock.Unlock()
+	e.events = []cloudevents.Event{}
+}

--- a/internal/cloudevents/test/http_receiver.go
+++ b/internal/cloudevents/test/http_receiver.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2023 The KubeArchive Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+	"net/http/httptest"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/client"
+	"github.com/go-logr/logr"
+	ctrlLog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var log logr.Logger
+
+type TestReceiver struct {
+	*httptest.Server
+	eventRecorder *EventRecorder
+}
+
+func NewTestReceiver(ctx context.Context) (*TestReceiver, error) {
+	recorder := NewEventRecorder()
+	handler, err := NewReceiverHTTPHandler(ctx, recorder)
+	if err != nil {
+		return nil, err
+	}
+	server := httptest.NewUnstartedServer(handler)
+	return &TestReceiver{
+		Server:        server,
+		eventRecorder: recorder,
+	}, nil
+}
+
+func NewReceiverHTTPHandler(ctx context.Context, recorder *EventRecorder) (*client.EventReceiver, error) {
+	protocol, err := cloudevents.NewHTTP()
+	if err != nil {
+		return nil, err
+	}
+	log = ctrlLog.Log.WithName("handler")
+	if recorder == nil {
+		recorder = NewEventRecorder()
+	}
+	eventHander := newEventHandler(recorder)
+	handler, err := cloudevents.NewHTTPReceiveHandler(ctx, protocol, eventHander.handleEvent)
+	if err != nil {
+		return nil, err
+	}
+	return handler, nil
+}
+
+func (r *TestReceiver) StartRecorder() {
+	r.eventRecorder.Start()
+}
+
+func (r *TestReceiver) StopRecorder() {
+	r.eventRecorder.Stop()
+}
+
+func (r *TestReceiver) ClearEvents() {
+	r.eventRecorder.Clear()
+}
+
+func (r *TestReceiver) GetEvents() []cloudevents.Event {
+	return r.eventRecorder.Events()
+}
+
+type eventHandler struct {
+	recorder *EventRecorder
+}
+
+func newEventHandler(recorder *EventRecorder) *eventHandler {
+	return &eventHandler{
+		recorder: recorder,
+	}
+}
+
+func (e *eventHandler) handleEvent(ctx context.Context, event cloudevents.Event) {
+	log.Info("received event", "event", event)
+	e.recorder.Record(event)
+}

--- a/internal/controller/job_controller_test.go
+++ b/internal/controller/job_controller_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2023 The KubeArchive Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("job controller", func() {
+
+	BeforeEach(func() {
+		Expect(testServer.GetEvents()).Should(BeEmpty())
+	})
+
+	AfterEach(func() {
+		testServer.StopRecorder()
+		testServer.ClearEvents()
+	})
+
+	It("sends a CloudEvent when a Job is created", func(ctx SpecContext) {
+		testServer.StartRecorder()
+		defer testServer.StopRecorder()
+		By("creating a Job object")
+		job := createJobFixture("default", "created-job")
+		Expect(k8sClient.Create(ctx, job)).Should(Succeed())
+		Eventually(ctx, testServer.GetEvents).ShouldNot(BeEmpty())
+	})
+
+	It("sends a CloudEvent when a Job is updated", func(ctx SpecContext) {
+		By("creating a Job object")
+		job := createJobFixture("default", "updated-job")
+		Expect(k8sClient.Create(ctx, job)).Should(Succeed(), "create job fixture")
+		Expect(testServer.GetEvents()).Should(BeEmpty(), "events are not recorded")
+		testServer.StartRecorder()
+		defer testServer.StopRecorder()
+		// Simulate that a pod is running
+		By("updating a Job object")
+		now := metav1.Now()
+		start := metav1.NewTime(now.Add(-1 * time.Second))
+		job.Status = batchv1.JobStatus{
+			Conditions: []batchv1.JobCondition{
+				{
+					Type:               batchv1.JobComplete,
+					Status:             corev1.ConditionUnknown,
+					Reason:             "Running",
+					LastProbeTime:      now,
+					LastTransitionTime: now,
+				},
+			},
+			Active:    1,
+			StartTime: &start,
+		}
+		Expect(k8sClient.Status().Update(ctx, job)).Should(Succeed(), "update job fixture")
+		Eventually(ctx, testServer.GetEvents).ShouldNot(BeEmpty())
+	})
+
+	It("sends a CloudEvent when a Job is deleted", func(ctx SpecContext) {
+		By("creating a Job object")
+		job := createJobFixture("default", "deleted-job")
+		Expect(k8sClient.Create(ctx, job)).Should(Succeed(), "create job fixture")
+		Expect(testServer.GetEvents()).Should(BeEmpty(), "events are not recorded")
+		testServer.StartRecorder()
+		defer testServer.StopRecorder()
+		By("deleting a Job object")
+		Expect(k8sClient.Delete(ctx, job)).Should(Succeed(), "delete job fixture")
+		Eventually(ctx, testServer.GetEvents).ShouldNot(BeEmpty())
+	})
+})
+
+func createJobFixture(namespace string, name string) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "hello",
+							Image: "busybox:1.28",
+							Command: []string{
+								"/bin/sh",
+								"-c",
+								"date; echo Hello world",
+							},
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyOnFailure,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Updating the "Job" controller to send a CloudEvent when an object is created, updated, or deleted. This requires the controller to be configured with a receiver to send events to. CloudEvents are chosen because they are a standard way to emit "events" in cloud-native applications. These events are agnostic to the receiver and can be integrated into other frameworks, like KNative Eventing.

The current implementation is a proof of concept that emits very simple data. Standardizing the format/API of the transmitted event data will come later. The proof of concept also includes a test-receiver binary, which acts as a dummy receiver of the emitted CloudEvents.